### PR TITLE
Updates to get H3 UDF working in Athena

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.vscode/*
+infrastructure/cdk.out
+infrastructure/target
+udf/target

--- a/README.md
+++ b/README.md
@@ -1,19 +1,27 @@
-## H3 UDF for Athena
+# H3 UDF for Athena
 
-This repository contains example code to support the blog post [Extend geospatial queries in Amazon Athena with UDFs and AWS Lambda](https://aws.amazon.com/blogs/big-data/extend-geospatial-queries-in-amazon-athena-with-udfs-and-aws-lambda/). The UDF makes it straightforward for [Amazon Athena](https://aws.amazon.com/athena/) to find out which [Uber H3](https://eng.uber.com/h3/) hexagon a pair of (lat, long) coordinates are in. This can be used for subsequent analysis and visualisation. 
+Forked from [aws-samples/h3-udf-for-athena](https://github.com/aws-samples/h3-udf-for-athena) for use at Neighbor. Differences include the following changes:
+
+- Readded `@Test` annotations for JUnit tests
+- Modified functions to work with GeoJSON-style WKT text, where coordinates are in the form of `longitude` `latitude`, as opposed to `latitude` `longitude`
+
+---
+
+This repository contains example code to support the blog post [Extend geospatial queries in Amazon Athena with UDFs and AWS Lambda](https://aws.amazon.com/blogs/big-data/extend-geospatial-queries-in-amazon-athena-with-udfs-and-aws-lambda/). The UDF makes it straightforward for [Amazon Athena](https://aws.amazon.com/athena/) to find out which [Uber H3](https://eng.uber.com/h3/) hexagon a pair of (lat, long) coordinates are in. This can be used for subsequent analysis and visualisation.
 
 We include code for the [AWS Lambda](https://aws.amazon.com/lambda/) function that powers the new Athena UDF. Also included is an example Jupyter Notebook which may be used in an [Amazon SageMaker Notbook Instance](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html) to render a choropleth map.
 
 ![Map](./media/earthquake_map.png "Example map.")
 
-### How to use
-- Package the UDF by going to udf directory, and launch ``` mvn clean package ```.
-- Run ``` cdk deploy``` in the infrastructure directory of the repository.  
+## How to use
 
-### Security
+- Package the UDF by going to udf directory, and launch `mvn clean package`.
+- Run `cdk deploy` in the infrastructure directory of the repository.  
+
+## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 
-### License
+## License
 
 This library is licensed under the MIT-0 License. See the LICENSE file.

--- a/infrastructure/META-INF/maven/aws.athena.udf.h3/aws-h3-athena-udf/pom.xml
+++ b/infrastructure/META-INF/maven/aws.athena.udf.h3/aws-h3-athena-udf/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.site.plugin.version>3.9.1</maven.site.plugin.version>
         <aws-athena-federation-sdk.version>2021.27.1</aws-athena-federation-sdk.version>
-        <h3.version>3.7.0</h3.version>
+        <h3.version>4.0.0</h3.version>
         <log4j2.version>2.17.1</log4j2.version>
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.30</slf4j.version>

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.myorg</groupId>
-    <artifactId>mydeploy</artifactId>
+    <groupId>neighbor.athena.udf.h3</groupId>
+    <artifactId>aws-h3-athena-udf</artifactId>
     <version>0.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <cdk.version>1.170.0</cdk.version>
         <junit.version>5.8.1</junit.version>
+        <maven.site.plugin.version>3.9.2</maven.site.plugin.version>
     </properties>
 
     <build>

--- a/infrastructure/src/main/java/com/aws/athena/udf/h3/infrastructure/AthenaUDFStack.java
+++ b/infrastructure/src/main/java/com/aws/athena/udf/h3/infrastructure/AthenaUDFStack.java
@@ -58,13 +58,12 @@ public class AthenaUDFStack extends Stack {
 
 
         // Creates the UDF.
-        final Function  udf = new Function(this, "H3AthenaHandler", FunctionProps.builder()
+        final Function udf = new Function(this, "H3AthenaHandler", FunctionProps.builder()
                 .runtime(Runtime.JAVA_11)
-                .code(Code.fromAsset("../", AssetOptions.builder()
-                        .bundling(builderOptions
-                                .command(udfPkgCommand)
-                                .build())
-                        .build()))
+                .code(
+                        Code.fromAsset("../", 
+                        AssetOptions.builder().bundling(builderOptions.command(udfPkgCommand).build()).build())
+                )
                 .handler("com.aws.athena.udf.h3.H3AthenaHandler")
                 .memorySize(MEMORY_SIZE)
                 .timeout(Duration.seconds(TIMEOUT))

--- a/infrastructure/src/main/java/com/aws/athena/udf/h3/infrastructure/AthenaUDFStack.java
+++ b/infrastructure/src/main/java/com/aws/athena/udf/h3/infrastructure/AthenaUDFStack.java
@@ -58,7 +58,7 @@ public class AthenaUDFStack extends Stack {
 
 
         // Creates the UDF.
-        final Function udf = new Function(this, "H3AthenaHandler", FunctionProps.builder()
+        new Function(this, "H3AthenaHandler", FunctionProps.builder()
                 .runtime(Runtime.JAVA_11)
                 .code(
                         Code.fromAsset("../", 

--- a/infrastructure/src/main/java/com/aws/athena/udf/h3/infrastructure/DeployApp.java
+++ b/infrastructure/src/main/java/com/aws/athena/udf/h3/infrastructure/DeployApp.java
@@ -13,9 +13,8 @@ public class DeployApp {
         final App app = new App();
 
         new AthenaUDFStack(app, "H3AthenaUDF", StackProps.builder()
-                .env(Environment.builder().build())
-                .build());
-
+            .env(Environment.builder().build())
+            .build());
         app.synth();
     }
 }

--- a/udf/pom.xml
+++ b/udf/pom.xml
@@ -14,6 +14,8 @@
     <junit.jupiter.version>5.8.1</junit.jupiter.version>
     <junit.platform.version>1.8.1</junit.platform.version>
     <slf4j.version>1.7.30</slf4j.version>
+    <simple-features-wkt.version>1.2.2</simple-features-wkt.version>
+    <simple-features.version>2.2.1</simple-features.version>
   </properties>
   <dependencies>
     <dependency>
@@ -65,9 +67,18 @@
             <version>${junit.platform.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>mil.nga</groupId>
+            <artifactId>sf</artifactId>
+            <version>${simple-features.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>mil.nga.sf</groupId>
+            <artifactId>sf-wkt</artifactId>
+            <version>${simple-features-wkt.version}</version>
+        </dependency>
   </dependencies>
   <build>
-
     <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/udf/src/main/java/com/aws/athena/udf/h3/H3AthenaHandler.java
+++ b/udf/src/main/java/com/aws/athena/udf/h3/H3AthenaHandler.java
@@ -12,24 +12,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
 
 /** Lambda that hosts H3 UDFs */
 public class H3AthenaHandler extends UserDefinedFunctionHandler {
 
     private final H3Core h3Core;
-
     private static final String SOURCE_TYPE = "h3_athena_udf_handler";
-
     private static final String LAT = "lat";
-
     private static final String LNG = "lng";
-
     private static final String POLYGON = "POLYGON";
 
     public H3AthenaHandler() throws IOException {
@@ -46,13 +37,8 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *   @throws IllegalArgumentException latitude, longitude, or resolution are out of range.
      */
     public Long lat_lng_to_cell(Double lat, Double lng, Integer res) {
-        final Long result;
-        if (lat == null || lng == null || res == null) {
-            result = null;
-        } else {
-           result = h3Core.latLngToCell(lat, lng, res);
-        }
-        return result;
+        return (lat == null || lng == null || res == null) ? null : 
+            h3Core.latLngToCell(lat, lng, res);
     }
 
     /** Indexes the location at the specified resolution, returning index of the cell as String containing
@@ -64,13 +50,8 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *   @throws IllegalArgumentException latitude, longitude, or resolution are out of range.
      */
     public String lat_lng_to_cell_address(Double lat, Double lng, Integer res) {
-        final String result;
-        if (lat == null || lng == null || res == null) {
-            result = null;
-        } else {
-            result =  h3Core.latLngToCellAddress(lat, lng, res);
-        }
-        return result;
+        return (lat == null || lng == null || res == null) ? null : 
+            h3Core.latLngToCellAddress(lat, lng, res);
     }
 
     /** Finds the centroid of an index, and returns an array list of coordinates representing latitude and longitude 
@@ -80,31 +61,23 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @throws IllegalArgumentException when the index is out of range
      */
     public List<Double> cell_to_lat_lng(Long h3) {
-        final List<Double> result;
-        if (h3 == null) {
-            result = null;
-        } else {
-            final LatLng coord = h3Core.cellToLatLng(h3);
-            result = new ArrayList<>(Arrays. asList(coord.lat, coord.lng));
-        }
-	    return result;
+        if (h3 == null) { return null; } 
+
+        final LatLng coord = h3Core.cellToLatLng(h3);
+        return new ArrayList<>(Arrays.asList(coord.lat, coord.lng));
     }
 
      /** Finds the centroid of an index, and returns an array list of coordinates representing latitude and longitude 
      *  respectively.
-     *  @param h3Address the H3 index
+     *  @param h3 the H3 index
      *  @return List of Double of size 2 representing latitude and longitude. Null when the index is null.
      *  @throws IllegalArgumentException when the index is out of range
      */
-    public List<Double> cell_to_lat_lng(String h3Address) {
-        final List<Double> result;
-        if (h3Address == null) {
-            result = null;
-        } else {
-            final LatLng coord = h3Core.cellToLatLng(h3Address);
-            result = new ArrayList<>(Arrays. asList(coord.lat, coord.lng));
-        }
-    return result;
+    public List<Double> cell_to_lat_lng(String h3) {
+        if (h3 == null) { return null; } 
+        
+        final LatLng coord = h3Core.cellToLatLng(h3);
+        return new ArrayList<>(Arrays.asList(coord.lat, coord.lng));
     }
 
     /** Finds the centroid of an index, and returns a WKT of the centroid.
@@ -112,15 +85,11 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @return the WKT of the centroid of an H3 index. Null when the index is null;
      *  @throws IllegalArgumentException when the index is out of range
      */
-    public String  cell_to_lat_lng_wkt(Long h3) {
-        final String result;
-        if (h3 == null) {
-            result = null;
-        } else {
-          final LatLng coord = h3Core.cellToLatLng(h3);
-          result = wktPoint(coord);
-        }
-        return result;        
+    public String cell_to_lat_lng_wkt(Long h3) {
+        if (h3 == null) { return null; }
+    
+        final LatLng coord = h3Core.cellToLatLng(h3);
+        return wktPoint(coord); 
     }
 
     /** Finds the centroid of an index, and returns a WKT of the centroid.
@@ -128,17 +97,12 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @return the WKT of the centroid of an H3 index. Null when the index is null;
      *  @throws IllegalArgumentException when the index is out of range
      */
-    public String  cell_to_lat_lng_wkt(String h3) {
-        final String result;
-        if (h3 == null) {
-            result = null;
-        } else {
-          final LatLng coord = h3Core.cellToLatLng(h3);
-          result = wktPoint(coord);
-        }
-        return result;        
+    public String cell_to_lat_lng_wkt(String h3) {
+        if (h3 == null) { return null; }
+    
+        final LatLng coord = h3Core.cellToLatLng(h3);
+        return wktPoint(coord);      
     }
-
 
     /** Finds the boundary of an H3 cell.
      * @param h3 the H3 cell
@@ -148,17 +112,12 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      * @throws IllegalArgumentException  when address is out of range 
      */
     public List<String> cell_to_boundary(Long h3, String sep){
-        final List<String> result;
-        if (h3 == null) {
-            result = null;
-        } else {
-            result =  h3Core.cellToBoundary(h3).stream()
-                            .map(n-> pointsListStr(n, sep))
-                            .collect(Collectors.toList()); 
-        }
-        return result;
+        if (h3 == null) { return null;}
+    
+        return h3Core.cellToBoundary(h3).stream()
+            .map(n-> pointsListStr(n, sep))
+            .collect(Collectors.toList());
     }
-
 
     /** Finds the boundary of an H3 index for a given coordinate system (lat=latitude, or lng=longitude)
      * @param h3 the H3 index
@@ -168,23 +127,13 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      * @throws IllegalArgumentException  when address is out of range  or when coordSys is unknown.
      */
     public List<Double> cell_to_boundary_sys(Long h3, String coordSys) {
-        final List<Double> result;
-        if (LAT.equals(coordSys) || LNG.equals(coordSys)) {
-            if (h3 == null) {
-                result = null;
-            } else {
-                result =  h3Core.cellToBoundary(h3).stream()
-                                .map(n-> coordSys.equals(LAT) ? n.lat : n.lng)
-                                .collect(Collectors.toList()); 
-            }
-        } else if (coordSys == null) {
-            result = null;
-        } else {
-            throw new IllegalArgumentException("Unknown coord sys");
-        }
-        return result;
+        if (h3 == null || coordSys == null) { return null; }
+        else if (!LAT.equals(coordSys) && !LNG.equals(coordSys)) { throw new IllegalArgumentException("Unknown coord sys"); }
+        
+        return h3Core.cellToBoundary(h3).stream()
+                .map(n-> coordSys.equals(LAT) ? n.lat : n.lng)
+                .collect(Collectors.toList());
     }
-
 
     /** Finds the boundary of an H3 index. Returns the result in an array of WKT points.
      * @param h3 the H3 index
@@ -193,35 +142,23 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      * @throws IllegalArgumentException  when address is out of range.
      */
     public List<String> cell_to_boundary_wkt(Long h3){
-        final List<String> result;
-        if (h3 == null) {
-            result = null;
-        } else {
-            result =  h3Core.cellToBoundary(h3).stream()
-                            .map(H3AthenaHandler::wktPoint)
-                            .collect(Collectors.toList());
-        }
-        return result;        
-
+        return (h3 == null) ? null :
+            h3Core.cellToBoundary(h3).stream()
+                .map(H3AthenaHandler::wktPoint)
+                .collect(Collectors.toList());
     }
-
     
     /** Finds the boundary of an H3 index in a string form.
-     * @param h3Address the H3 index
+     * @param h3 the H3 index
      * @return the list of points representing the points in the boundary. Each returned list consists of two members, the first one is latitude, and the 
      * second one is longitude . Null when the h3Address is null.
      * @throws IllegalArgumentException  when address is out of range.
      */
-    public List<String> cell_to_boundary_wkt(String h3Address){
-        final List<String> result;
-        if (h3Address == null) {
-           result = null;
-        } else {
-           result = h3Core.cellToBoundary(h3Address).stream()
-                          .map(H3AthenaHandler::wktPoint)
-                          .collect(Collectors.toList());
-        }
-        return result;
+    public List<String> cell_to_boundary_wkt(String h3){
+        return (h3 == null) ? null :
+            h3Core.cellToBoundary(h3).stream()
+                .map(H3AthenaHandler::wktPoint)
+                .collect(Collectors.toList());
     
     }
     
@@ -233,23 +170,12 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      * @throws IllegalArgumentException  when address is out of range. 
      */
     public List<Double> cell_to_boundary_sys(String h3Address, String coordSys){
-        final List<Double> result;
-        if (LAT.equals(coordSys) || LNG.equals(coordSys)) {
-
-            if (h3Address == null) {
-                result = null;
-            }
-            else { 
-                result =  h3Core.cellToBoundary(h3Address).stream()
-                                .map(n-> coordSys.equals(LAT) ? n.lat : n.lng)
-                                .collect(Collectors.toList());
-            }
-        } else if (coordSys == null) {
-            result = null;
-        } else {
-            throw new IllegalArgumentException("Unknown coordSys");
-        }
-        return result;
+        if (h3Address == null || coordSys == null) { return null; }
+        else if (!LAT.equals(coordSys) && !LNG.equals(coordSys)) { throw new IllegalArgumentException("Unknown coord sys"); }
+        
+        return h3Core.cellToBoundary(h3Address).stream()
+                .map(n-> coordSys.equals(LAT) ? n.lat : n.lng)
+                .collect(Collectors.toList());
     }
 
     /** Finds the boundary of an H3 address.
@@ -260,18 +186,11 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      * @throws IllegalArgumentException  when address is out of range 
      */
     public List<String> cell_to_boundary(String h3Address, String sep){
-        final List<String> result;
-        if (h3Address == null || sep == null) {
-            result = null;
-        } else {
-            result =  h3Core.cellToBoundary(h3Address).stream()
+        return (h3Address == null || sep == null) ? null : 
+            h3Core.cellToBoundary(h3Address).stream()
                             .map(n-> pointsListStr(n, sep))
-                            .collect(Collectors.toList()); 
-        }
-        return result;
+                            .collect(Collectors.toList());
     }
-
-
 
     /** Returns the resolution of an index.
      *  @param h3 the H3 index.
@@ -279,28 +198,15 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @throws  IllegalArgumentException  when index is out of range.
      */
     public Integer get_resolution(Long h3){
-        final Integer result;
-        if (h3 == null) {
-            result = null;
-        } else {
-            result = h3Core.getResolution(h3);
-        }
-        return result;
+        return h3 == null ? null : h3Core.getResolution(h3);
     }
-
 
     /** Returns the resolution of an index.
      *  @param h3Address the H3 index in string form.
      *  @return the resolution. Null when h3Address is null.
      */
     public Integer get_resolution(String h3Address){
-        final Integer result;
-        if (h3Address == null) {
-            result = null;
-        } else {
-            result =  h3Core.getResolution(h3Address);
-        }
-        return result;
+        return h3Address == null ? null : h3Core.getResolution(h3Address);
     }
 
     /** Returns the base cell number of the index.
@@ -447,14 +353,7 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *   @return the h3 indexes. 
      */  
     public List<Long> grid_path_cells(Long start, Long end) {
-        List<Long> result;
-        if (start == null || end == null) {
-            result =  null;
-        } else {
-            result = h3Core.gridPathCells(start, end);
-        }
-        return result;
-
+        return (start == null || end == null) ? null : h3Core.gridPathCells(start, end);
     }
 
     /** Given two H3 indexes, return the line of indexes between them (inclusive).
@@ -462,17 +361,9 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *   @param end the h3 address of end of the line.
      *   @return the h3 addresses 
      */
-    public List<String> grid_path_cells(String startAddress, String endAddress)  {
-        List<String> result;
-        if (startAddress == null || endAddress == null) {
-            result = null;
-        }
-        else {
-           result = h3Core.gridPathCells(startAddress, endAddress);
-        }
-        return result;
+    public List<String> grid_path_cells(String start, String end)  {
+        return (start == null || end == null) ? null : h3Core.gridPathCells(start, end);
     }
-
     
      /** Returns the distance in grid cells between the two addresses.
      *   Returns a negative number if finding the distance failed. Finding the distance can fail because the two indexes are not 
@@ -482,15 +373,11 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @return the distance.
      */
     public Long grid_distance(Long a, Long b){
-        final Long result;
-        if (a == null || b == null) {
-            result =  null;
-        } else if (h3Core.getResolution(a) == h3Core.getResolution(b)) {
-            result =  h3Core.gridDistance(a, b);
-        } else {
+        if (a == null || b == null) { return  null; }
+        else if (h3Core.getResolution(a) != h3Core.getResolution(b)) {
             throw new IllegalArgumentException("Cannot compute distance of two indexes from different resolutions");
-        } 
-        return result;       
+        }
+        return h3Core.gridDistance(a, b);
     }
 
     /** Returns the distance in grid cells between the two addresses.
@@ -501,15 +388,11 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @return the distance.
      */
     public Long grid_distance(String a, String b) {
-        final Long result;
-        if (a == null || b == null) {
-            result =  null;
-        } else if (h3Core.getResolution(a) == h3Core.getResolution(b)) {
-            result = h3Core.gridDistance(a, b);
-        } else {
+        if (a == null || b == null) { return  null; }
+        else if (h3Core.getResolution(a) != h3Core.getResolution(b)) {
             throw new IllegalArgumentException("Cannot compute distance of two indexes from different resolutions");
         }
-        return result;
+        return h3Core.gridDistance(a, b);
     }
 
     /** Returns the direct parent (parent resolution = resolution -1) index containing h.
@@ -535,19 +418,14 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
       * @return parent index containing h or null when h3 is null.
       */
     public List<Long> cell_to_parents(Long h3) {
-        final List<Long> result;
-        if (h3 == null) {
-            result = null;
-        }
-        else {
-            result = new LinkedList<>();
-            for (int res = get_resolution(h3) - 1; res >= 0 ; --res) {
-                result.add(cell_to_parent(h3, res));
-            }
+        if (h3 == null) { return null; }
+        
+        final List<Long> result = new LinkedList<>();
+        for (int res = get_resolution(h3) - 1; res >= 0 ; --res) {
+            result.add(cell_to_parent(h3, res));
         }
         return result;
     }
-
 
     /** Returns the parent (coarser) index containing h3Address. 
      *  @param h3Address the h3 address of an h3 cell.
@@ -556,13 +434,8 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      * 
      */
     public String cell_to_parent(String h3Address, Integer parentRes) {
-        final String result;
-        if (h3Address == null || parentRes == null){
-            result = null;
-        } else {
-            result = h3Core.cellToParentAddress(h3Address, parentRes);
-        }
-        return result;
+        return (h3Address == null || parentRes == null) ? null :
+            h3Core.cellToParentAddress(h3Address, parentRes);
     }
 
     /** Returns all the parents up to resolution 0. 
@@ -570,19 +443,14 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
       * @return parent index containing h or null when h3 is null.
       */
     public List<String> cell_to_parents(String h3Address) {
-        final List<String> result;
-        if (h3Address == null) {
-            result = null;
-        }
-        else {
-            result = new LinkedList<>();
-            for (int res = h3Core.getResolution(h3Address) - 1; res >= 0 ; --res) {
-                result.add(cell_to_parent(h3Address, res));
-            }
+        if (h3Address == null) { return null; }
+        
+        final List<String> result = new LinkedList<>();
+        for (int res = h3Core.getResolution(h3Address) - 1; res >= 0 ; --res) {
+            result.add(cell_to_parent(h3Address, res));
         }
         return result;
     }
-
 
     /** Returns the direct parent (parent resolution = resolution -1) index containing h.
       * @param h the h3 index.
@@ -618,16 +486,12 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @return the h3 indexes of the children
      */
     public List<Long> cell_to_descendants(Long h3, Integer depth) {
-        final List<Long> result;
-
-        if (h3 == null || depth == null || depth <= 0) {
-            result = null;
-        }  else {
-            final int resolution = get_resolution(h3);
-            result = new LinkedList<>();
-            for (int i = 1; i <= depth; ++i) {
-                result.addAll(cell_to_children(h3, resolution + i));
-            }
+        if (h3 == null || depth == null || depth <= 0) { return null; }
+        
+        final int resolution = get_resolution(h3);
+        final List<Long> result = new LinkedList<>();
+        for (int i = 1; i <= depth; ++i) {
+            result.addAll(cell_to_children(h3, resolution + i));
         }
         return result;
     }
@@ -639,16 +503,12 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @return the h3 indexes of the children
      */
     public List<String> cell_to_descendants(String h3Address, Integer depth) {
-        final List<String> result;
-
-        if (h3Address == null || depth == null || depth <= 0) {
-            result = null;
-        }  else {
-            final int resolution = get_resolution(h3Address);
-            result = new LinkedList<>();
-            for (int i = 1; i <= depth; ++i) {
-                result.addAll(cell_to_children(h3Address, resolution + i));
-            }
+        if (h3Address == null || depth == null || depth <= 0) { return null; }
+        
+        final int resolution = get_resolution(h3Address);
+        final List<String> result = new LinkedList<>();
+        for (int i = 1; i <= depth; ++i) {
+            result.addAll(cell_to_children(h3Address, resolution + i));
         }
         return result;
     }
@@ -672,37 +532,26 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
     }
 
     public List<Long> cell_to_center_descendants(Long h3, Integer depth) {
-        final List<Long> result;
-
-        if (h3 == null || depth == null) {
-            result = null;
-        } else {
-            result = new LinkedList<>();
-            for (int i = 1; i <= depth; ++i) {
-                result.add(cell_to_center_child(
-                                h3, 
-                                get_resolution(h3) + i));
-            }
+        if (h3 == null || depth == null) { return null; }
+        
+        final int resolution = get_resolution(h3);
+        final List<Long> result = new LinkedList<>();
+        for (int i = 1; i <= depth; ++i) {
+            result.add(cell_to_center_child(h3, resolution + i));
         }
         return result;
     }
 
     public List<String> cell_to_center_descendants(String h3Address, Integer depth) {
-        final List<String> result;
-
-        if (h3Address == null || depth == null) {
-            result = null;
-        } else {
-            result = new LinkedList<>();
-            for (int i = 1; i <= depth; ++i) {
-                result.add(cell_to_center_child(
-                                h3Address, 
-                                get_resolution(h3Address) + i));
-            }
+        if (h3Address == null || depth == null) { return null; } 
+        
+        final int resolution = get_resolution(h3Address);
+        final List<String> result = new LinkedList<>();
+        for (int i = 1; i <= depth; ++i) {
+            result.add(cell_to_center_child(h3Address, resolution + i));
         }
         return result;
     }
-
  
     /** Returns the center child (finer) index contained by h at resolution childRes.
      * @param h3 the h3 index
@@ -723,7 +572,6 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
     public List<Long> compact_cells(List<Long> h3){
         return h3 == null ? null : h3Core.compactCells(h3);
     }
-
  
     /** Compacts the set h3Set of indexes as best as possible, into the array compacted set. 
      *  This function compacts a set of cells of the same resolution into a set of cells across multiple 
@@ -745,7 +593,6 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
     public List<Long> uncompact_cells(List<Long> h3, Integer res) {
         return h3 == null || res == null ? null : h3Core.uncompactCells(h3, res);
     }
- 
 
     /** This function uncompacts a compacted set of H3 cells to indices of the target resolution.
      *  @param h3 the list of indices, may be in different resolutions
@@ -778,10 +625,10 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
                 for (final String coordinates:strippedPolygon.substring(2, strippedPolygon.length() - 2).split(",")) {
                     
                     final String[] splitCoordinates = coordinates.trim().split("\\s+");
+                    Double lat = Double.parseDouble(splitCoordinates[1]);
+                    Double lng = Double.parseDouble(splitCoordinates[0]);
 
-                    geoCoordPoints.add(new LatLng(
-                                            Double.parseDouble(splitCoordinates[0]),
-                                            Double.parseDouble(splitCoordinates[1])));
+                    geoCoordPoints.add(new LatLng(lat, lng));
                 }
                 final List<List<LatLng>> geoCoordHoles = new ArrayList<>();
                 result = h3Core.polygonToCells(geoCoordPoints, geoCoordHoles, res);
@@ -790,7 +637,6 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
             }
             
         }
-
         return result;
     }
     
@@ -805,30 +651,35 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
 
         if (polygonWKT == null || res == null) {
             result = null;
+            System.out.println("polygonWKT is null or res is null");
         } else {
+            System.out.println("Starting loop");
             final List<LatLng> geoCoordPoints = new LinkedList<>();
 
             final String trimmed = polygonWKT.trim();
 
             if (trimmed.startsWith(POLYGON) && trimmed.endsWith("))")) {
+                System.out.println("Valid polygon");
                 final String strippedPolygon  = trimmed.substring(POLYGON.length()).trim();
-                final String [] allCoordinates = strippedPolygon.substring(2, strippedPolygon.length() - 2)
-                                                                .split(",");
+                final String [] allCoordinates = strippedPolygon.substring(2, strippedPolygon.length() - 2).split(",");
 
+                System.out.println("Number of coordinates found: " + allCoordinates.length);
                 for (final String coordinates : allCoordinates) {
 
                     final String[] splitCoordinates = coordinates.trim().split("\\s+");
+                    Double lat = Double.parseDouble(splitCoordinates[1]);
+                    Double lng = Double.parseDouble(splitCoordinates[0]);
 
-                    geoCoordPoints.add(
-                        new LatLng(Double.parseDouble(splitCoordinates[0]), 
-                                     Double.parseDouble(splitCoordinates[1])));
+                    geoCoordPoints.add(new LatLng(lat, lng));
                 }
                 final List<List<LatLng>> geoCoordHoles = new ArrayList<>();
+
                 result = h3Core.polygonToCellAddresses(geoCoordPoints, geoCoordHoles, res);
+                System.out.println("Number of results found: " + result.size());
+
             } else {
                 throw new IllegalArgumentException("invalid polygonWKT");
             }
-            
         }
         return result;
     }
@@ -869,11 +720,9 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
                         else {
                             multiPolygonWKT.append(", ");
                         }
-
-                        multiPolygonWKT.append(coord.lat).append(" ").append(coord.lng);
+                        multiPolygonWKT.append(coord.lng).append(" ").append(coord.lat);
                     }
                     multiPolygonWKT.append(")");
-
                 }
                 multiPolygonWKT.append(")");
             }
@@ -889,7 +738,7 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @return WKT Polygon
      */
     public String cells_to_multi_polygon(List<Long> h3, Boolean geoJson) {
-        return geoJson == null? null : cellsToMultiPolygon(h3, null, geoJson);
+        return geoJson == null ? null : cellsToMultiPolygon(h3, null, geoJson);
     }
 
     /** Gets a multipolygon WKT given an h3 set. 
@@ -898,9 +747,8 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @return WKT Polygon
      */
     public String cell_addresses_to_multi_polygon(List<String> h3Addresses, Boolean geoJson) {
-        return geoJson == null? null : cellsToMultiPolygon(null, h3Addresses, geoJson);
+        return geoJson == null ? null : cellsToMultiPolygon(null, h3Addresses, geoJson);
     }
-
 
     /** Returns whether or not the provided H3Indexes are neighbors.
      *  @param origin the first h3 index
@@ -908,11 +756,8 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @return true when the two h3 indexes are neighbors.
      */
     public Boolean are_neighbor_cells(Long origin, Long destination){
-        return origin == null || destination == null ? null : 
-                                                       h3Core.areNeighborCells(
-                                                            origin, destination
-                                                       );
-     
+        return (origin == null || destination == null) ? null : 
+            h3Core.areNeighborCells(origin, destination);
     }
 
     /** Returns whether or not the provided H3 addresses are neighbors.
@@ -921,8 +766,8 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @return true when the two h3 adresses are neighbors.
      */
     public Boolean are_neighbor_cells(String origin, String destination){
-        return origin == null || destination == null ? null : h3Core.areNeighborCells(
-                                                                origin, destination);
+        return (origin == null || destination == null) ? null : 
+            h3Core.areNeighborCells(origin, destination);
     }
 
     /** Returns a unidirectional edge H3 index based on the provided origin and destination.
@@ -942,7 +787,7 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      */
     public String cells_to_directed_edge(String origin, String destination) {
         return origin == null || destination == null ? null :
-                                    h3Core.cellsToDirectedEdge(origin, destination);
+            h3Core.cellsToDirectedEdge(origin, destination);
       }
 
     /** Determines if the provided H3Index is a valid unidirectional edge index.
@@ -952,7 +797,6 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
     public Boolean is_valid_directed_edge(Long edge){
         return edge != null && h3Core.isValidDirectedEdge(edge);
     }
-
 
     /** Determines if the provided H3 edge address is a valid unidirectional edge index.
      * @param edgeAddress the edge address
@@ -984,12 +828,10 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
         return edge == null ? null : h3Core.getDirectedEdgeDestination(edge);
     }
 
-  
     /** Returns the destination hexagon from the unidirectional edge address. */
     public String get_directed_edge_destination(String edgeAddress){
-        return edgeAddress == null ? null :
-                                        h3Core.getDirectedEdgeDestination(
-                                            edgeAddress);
+        return edgeAddress == null ? null : 
+            h3Core.getDirectedEdgeDestination(edgeAddress);
     }
 
     /** Returns origin and destination hexagons from a unidrectional edge. 
@@ -997,14 +839,8 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      * @return list of two elements , the first one is the origin, and the second one is the destination.
      */
     public List<Long> get_directed_edge_origin_destination(Long edge) {
-        final List<Long> result;
-        if (edge == null) {
-            result = null;
-        } else {
-            result = List.of(get_directed_edge_origin(edge),
-                             get_directed_edge_destination(edge));
-        }
-        return result;
+        return (edge == null) ? null :
+            List.of(get_directed_edge_origin(edge), get_directed_edge_destination(edge));
     }
 
     /** Returns origin and destination hexagons from a unidrectional edge. 
@@ -1012,17 +848,9 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      * @return array of two elements , the first one is the origin, and the second one is the destination.
      */
     public List<String> get_directed_edge_origin_destination(String edge) {
-        final List<String> result;
-        if (edge == null) {
-            result = null;
-        } else {
-            result=List.of(get_directed_edge_origin(edge),
-                           get_directed_edge_destination(edge));
-                    
-        }
-        return result;
+        return (edge == null) ? null :
+            List.of(get_directed_edge_origin(edge), get_directed_edge_destination(edge));
     }
-
 
     /** Provides all of the unidirectional edges from the current H3Index. 
      *  @param h3 the h3 index.
@@ -1032,7 +860,6 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
     public List<Long> origin_to_directed_edges(Long h3){
         return h3 == null ? null : h3Core.originToDirectedEdges(h3);
     }
-    
 
     /** Provides all of the unidirectional edges from the current H3 address. 
      *  @param h3 the h3 address 
@@ -1042,15 +869,15 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
         return h3 == null ? null : h3Core.originToDirectedEdges(h3);
     }
 
-
     /** Get the vertices of a given edge as a list of WKT oints
      *  @param edge an edge
      *  @return all points in WKT Points format.
      */
     public List<String> directed_edge_to_boundary(Long edge){
-        return edge == null ?  null : h3Core.directedEdgeToBoundary(edge).stream()
-                                               .map(H3AthenaHandler::wktPoint)
-                                               .collect(Collectors.toList());
+        return edge == null ? null : 
+            h3Core.directedEdgeToBoundary(edge).stream()
+                .map(H3AthenaHandler::wktPoint)
+                .collect(Collectors.toList());
     }
 
     /** Produces local IJ coordinates for an H3 index anchored by an origin.
@@ -1059,14 +886,10 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @param h3 the cell.
      */
     public List<Integer> cell_to_local_ij(Long origin, Long h3) {
-        final List<Integer> result;
-        if (origin == null || h3 == null) {
-            result = null;
-        } else {
-            final CoordIJ coord = h3Core.cellToLocalIj(origin, h3);
-            result = new ArrayList<>(Arrays. asList(coord.i, coord.j));
-        }
-        return result;
+        if (origin == null || h3 == null) { return null; }
+
+        final CoordIJ coord = h3Core.cellToLocalIj(origin, h3);
+        return new ArrayList<>(Arrays.asList(coord.i, coord.j));
     }
 
     /** Produces local IJ coordinates for an H3 index anchored by an origin.
@@ -1075,14 +898,10 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  @param h3 the cell.
      */
     public List<Integer> cell_to_local_ij(String origin, String h3) {
-        final List<Integer> result;
-        if (origin == null || h3 == null) {
-            result = null;
-        } else {
-            final CoordIJ coord = h3Core.cellToLocalIj(origin, h3);
-            result = new ArrayList<>(Arrays. asList(coord.i, coord.j));
-        }
-        return result;
+        if (origin == null || h3 == null) { return null; }
+
+        final CoordIJ coord = h3Core.cellToLocalIj(origin, h3);
+        return new ArrayList<>(Arrays.asList(coord.i, coord.j));
     }
 
     /** Provides all of the unidirectional edges from the current H3Index. 
@@ -1097,16 +916,15 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
                                                     .collect(Collectors.toList());
     }
 
-
     /** Average hexagon area in unit of area at the given resolution. 
      *  @param res resolution 
      *  @param unit the unit of area, km2 or m2.
      *  @return the area. 
      */
     public Double cell_area(Integer res, String unit) {
-        return  res == null || unit == null ? null : h3Core.cellArea(res, AreaUnit.valueOf(unit));
+        return res == null || unit == null ? null : 
+            h3Core.cellArea(res, AreaUnit.valueOf(unit));
     }
-
 
     /** Average hexagon edge length  at a given resolution.
      *  @param res the resolution
@@ -1115,11 +933,10 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
      *  
      */
     public Double get_hexagon_edge_length_avg(Integer res, String unit){
-        return res == null || unit == null ? null : h3Core.getHexagonEdgeLengthAvg(res, LengthUnit.valueOf(unit));
+        return res == null || unit == null ? null : 
+            h3Core.getHexagonEdgeLengthAvg(res, LengthUnit.valueOf(unit));
     }
 
-
-   
     /** Returns the total count of hexagons in the world at a given resolution. 
      * @param res the resolution.
      * @return the number of hexagons at a given resolution.
@@ -1127,7 +944,6 @@ public class H3AthenaHandler extends UserDefinedFunctionHandler {
     public Long get_num_cells(Integer res){
         return res == null ? null : h3Core.getNumCells(res);
     }
-
 
     /** Returns all the resolution 0 h3 indexes.
      *  @param dummy a dummy parameter, ignored.

--- a/udf/src/test/java/com/aws/athena/udf/h3/H3AthenaHandlerTest.java
+++ b/udf/src/test/java/com/aws/athena/udf/h3/H3AthenaHandlerTest.java
@@ -21,7 +21,7 @@ import java.util.Random;
 public class H3AthenaHandlerTest 
 {
     final private static String LNG = "lng";
-    final private static String LAT = "lat";   
+    final private static String LAT = "lat";
     final private H3AthenaHandler handler;
     final private H3Core h3Core;
 

--- a/udf/src/test/java/com/aws/athena/udf/h3/H3AthenaHandlerTest.java
+++ b/udf/src/test/java/com/aws/athena/udf/h3/H3AthenaHandlerTest.java
@@ -351,27 +351,31 @@ public class H3AthenaHandlerTest
         final double longitude = -4.3;
 
         for (int res = 2; res < 16; ++res) {
-        
             final Long h3 = handler.lat_lng_to_cell(latitude, longitude, res);
-            final String h3Address = handler.lat_lng_to_cell_address(latitude, longitude, res);
-
             for (final Long index : handler.grid_disk(h3, 5)) {
                 final List<Long> line = handler.grid_path_cells(h3, index);
-                final List<Long> lineAddr = handler.grid_path_cells(h3, index);
-
                 assertEquals(line.get(0), h3);
                 assertEquals(line.get(line.size() -1), index);
                 
                 for (int i = 0; i < line.size(); ++i) {
                     assertEquals(i, handler.grid_distance(h3, line.get(i)));
-                    assertEquals(i, handler.grid_distance(h3, lineAddr.get(i)));
+                }
+            }
+
+            final String h3Address = handler.lat_lng_to_cell_address(latitude, longitude, res);
+            for (final String index : handler.grid_disk(h3Address, 5)) {
+                final List<String> lineAddr = handler.grid_path_cells(h3Address, index);
+                assertEquals(lineAddr.get(0), h3Address);
+                assertEquals(lineAddr.get(lineAddr.size() -1), index);
+                
+                for (int i = 0; i < lineAddr.size(); ++i) {
+                    assertEquals(i, handler.grid_distance(h3Address, lineAddr.get(i)));
                 }
             }
         }
         assertNull(handler.grid_path_cells(handler.lat_lng_to_cell(latitude, longitude, 5), null));
         assertNull(handler.grid_path_cells((Long)null, handler.lat_lng_to_cell(latitude, longitude, 3)));
         assertNull(handler.grid_path_cells((String)null, handler.lat_lng_to_cell_address(latitude, longitude, 3)));
-
     }
 
     @Test

--- a/udf/src/test/java/com/aws/athena/udf/h3/H3AthenaHandlerTest.java
+++ b/udf/src/test/java/com/aws/athena/udf/h3/H3AthenaHandlerTest.java
@@ -20,13 +20,9 @@ import java.util.Random;
  */
 public class H3AthenaHandlerTest 
 {
-
     final private static String LNG = "lng";
-
-    final private static String LAT = "lat";
-    
+    final private static String LAT = "lat";   
     final private H3AthenaHandler handler;
-
     final private H3Core h3Core;
 
     /**
@@ -43,16 +39,12 @@ public class H3AthenaHandlerTest
     @Test
     public void testlat_lng_to_cell() 
     {
-        
         assertNull(handler.lat_lng_to_cell(null, 10.5, 1));
         assertNull(handler.lat_lng_to_cell(-10.4, null, 2));
         assertNull(handler.lat_lng_to_cell(10.4, 13.2, null));
 
-
         final Random r = new Random();
-
         for (int i=0; i < 1000; ++i) {
-
             final double latitude = Math.random() * 180.0 - 90.0;
             final double longitude = Math.random() * 360.0 - 180.0;
 
@@ -68,26 +60,19 @@ public class H3AthenaHandlerTest
             }
             else {
                 assertFalse(handler.lat_lng_to_cell(latitude, longitude,res)  == h3Core.latLngToCell(latitudeOther, longitudeOther,res));
-
             }
-
-            
         }
     }
 
     @Test
     public void testlat_lng_to_cell_address() 
     {
-        
         assertNull(handler.lat_lng_to_cell_address(null, 10.5, 1));
         assertNull(handler.lat_lng_to_cell_address(-10.4, null, 2));
         assertNull(handler.lat_lng_to_cell_address(10.4, 13.2, null));
 
-
         final Random r = new Random();
-
         for (int i=0; i < 1000; ++i) {
-
             final double latitude = Math.random() * 180.0 - 90.0;
             final double longitude = Math.random() * 360.0 - 180.0;
 
@@ -103,30 +88,24 @@ public class H3AthenaHandlerTest
             }
             else {
                 assertFalse(handler.lat_lng_to_cell_address(latitude, longitude,res).equals(h3Core.latLngToCellAddress(latitudeOther, longitudeOther,res)));
-
             }
-            
         }
     }
 
     @Test
     public void testget_icosahedron_faces() {
-
         final double latitude = 43.0;
         final double longitude = -42;
 
         assertNull(handler.get_icosahedron_faces((Long)null));
         assertNull(handler.get_icosahedron_faces((String)null));
-
         for (int i = 0; i < 16; ++i) {
             final Long h3 = handler.lat_lng_to_cell(latitude, longitude, i);
             final Long h3Address = handler.lat_lng_to_cell(latitude, longitude, i);
 
             assertEquals(h3Core.getIcosahedronFaces(h3), handler.get_icosahedron_faces(h3));
             assertEquals(h3Core.getIcosahedronFaces(h3Address), handler.get_icosahedron_faces(h3Address));
-
         }
-
     }
 
     @Test
@@ -145,7 +124,6 @@ public class H3AthenaHandlerTest
 
         assertNull(handler.grid_disk(h3, null));
         assertNull(handler.grid_disk(h3Address, null));
-
 
         final int kmax = 5;
 
@@ -180,7 +158,6 @@ public class H3AthenaHandlerTest
 
         assertNull(handler.grid_ring_unsafe(h3, null));
         assertNull(handler.grid_ring_unsafe(h3Address, null));
-
 
         final int kmax = 5;
 
@@ -225,7 +202,6 @@ public class H3AthenaHandlerTest
                 assertTrue(handler.is_pentagon(index));
                 assertEquals(h3Core.isPentagon(index), handler.is_pentagon(index));
             }
-
         }
     }
 
@@ -234,7 +210,6 @@ public class H3AthenaHandlerTest
         assertNull(handler.cell_to_lat_lng((Long)null));
 
         final Random r = new Random();
-
         for (int i=0; i < 1000; ++i) {
             final double latitude = Math.random() * 180.0 - 90.0;
             final double longitude = Math.random() * 360.0 - 180.0;
@@ -253,7 +228,6 @@ public class H3AthenaHandlerTest
             final Long centroidAddr = handler.lat_lng_to_cell(geo.get(0), geo.get(1), res);
 
             assertEquals(handler.cell_to_lat_lng(centroidAddr), geoFromAddress);
-            
         }
     }
 
@@ -298,13 +272,10 @@ public class H3AthenaHandlerTest
 
         assertEquals(handler.get_base_cell_number(h3), handler.get_base_cell_number(h3Address));
         assertEquals(h3Core.getBaseCellNumber(h3), handler.get_base_cell_number(h3Address));
-
-        
     }
 
     @Test
     public void teststring_to_h3_two_ways() {
-
         final double latitude = Math.random() * 180.0 - 90.0;
         final double longitude = Math.random() * 360.0 - 180.0;
         
@@ -342,7 +313,6 @@ public class H3AthenaHandlerTest
                       handler.cell_to_boundary_wkt(h3));
         assertEquals( Arrays.asList(boundaries), 
                       handler.cell_to_boundary_wkt(h3Address));
-
     } 
 
     @Test
@@ -396,7 +366,6 @@ public class H3AthenaHandlerTest
         final Long directParent = handler.cell_direct_parent(h3);
         assertEquals(handler.get_resolution(h3) -1, 
                      handler.get_resolution(directParent));
-
     }
 
     @Test
@@ -417,7 +386,6 @@ public class H3AthenaHandlerTest
                     handler.cell_to_center_child(h3, res + 1));
         assertEquals(h3Core.cellToCenterChild(h3Address, res + 1),
                     handler.cell_to_center_child(h3Address, res + 1));
-
     }
 
     @Test
@@ -450,10 +418,7 @@ public class H3AthenaHandlerTest
                             handler.uncompact_cells(compacted, res + 3 ));
             assertEquals(h3Core.uncompactCellAddresses(compactedAddress, res + 3), 
                             handler.uncompact_cell_addresses(compactedAddress, res + 3));
-            
-
         }
-
     }
 
     @Test
@@ -488,20 +453,16 @@ public class H3AthenaHandlerTest
             assertTrue(handler.get_resolution(desc) > res &&
                       handler.get_resolution(desc) <= res + 5);
         }
-
-
     }
 
 
     /** Tests cell_to_boundary functions as well as cell_to_boundary_sys. */
     @Test
     public void testcell_to_boundary() {
-
         assertNull(handler.cell_to_boundary((Long)null, ","));
         assertNull(handler.cell_to_boundary((String)null, ","));
         assertNull(handler.cell_to_boundary_sys((Long)null, LNG));
         assertNull(handler.cell_to_boundary_sys((String)null, LNG));
-
         
         final double latitude = 50.0;
         final double longitude = -43;
@@ -518,7 +479,6 @@ public class H3AthenaHandlerTest
 
         Assertions.assertThrows(IllegalArgumentException.class,
                         () -> handler.cell_to_boundary_sys(h3, "unk"));
-
 
         for (int i = 0; i < 6; ++i) {
             
@@ -584,7 +544,7 @@ public class H3AthenaHandlerTest
     }
 
     @Test
-    public void testpolygon_to_cells() {
+    public void testpolygon_to_cells() throws Exception {
         final String polygonWKT = 
             "POLYGON ((1.444209 43.604652, -1.553621 47.218371, 3.05726 50.62925, 2.349014 48.864716, 7.27178 43.6961, 1.444209 43.604652))";
         final List<LatLng> latLngPoints = List.of(new LatLng(43.604652,1.444209),
@@ -601,28 +561,66 @@ public class H3AthenaHandlerTest
         for (int i = 0; i <= 5 ;++i) {
             assertEquals(h3Core.polygonToCells(latLngPoints, empty, i), handler.polygon_to_cells(polygonWKT, i));
             assertEquals(handler.polygon_to_cells(polygonWKT, i), handler.polygon_to_cells(polygonWKTAlt, i));
-
         }
     }
 
     // @Test
-    public void testpolygon_to_cell_addresses() {
-        final String polygonWKT = "POLYGON((43.604652 1.444209, 47.218371 -1.553621, 50.62925 3.05726, 48.864716 2.349014, 43.6961 7.27178, 43.604652 1.444209))";
+    public void testpolygon_to_cell_addresses() throws Exception{
+        final String polygonWKT = 
+            "POLYGON ((1.444209 43.604652, -1.553621 47.218371, 3.05726 50.62925, 2.349014 48.864716, 7.27178 43.6961, 1.444209 43.604652))";
         final List<LatLng> latLngPoints = List.of(new LatLng(43.604652,1.444209),
                                                       new LatLng(47.218371, -1.553621),
                                                       new LatLng(50.62925, 3.05726),
                                                       new LatLng(48.864716, 2.349014),
                                                       new LatLng(43.6961, 7.27178),
                                                       new LatLng(43.604652, 1.444209));
-        final String polygonWKTAlt = "POLYGON ((43.604652 1.444209, 47.218371 -1.553621, 50.62925 3.05726, 48.864716 2.349014, 43.6961 7.27178, 43.604652 1.444209))";
 
-        final List<List<LatLng>>  empty = new LinkedList<>();
+        final String polygonWKTAlt = 
+            "POLYGON ((1.444209 43.604652, -1.553621 47.218371, 3.05726 50.62925, 2.349014 48.864716, 7.27178 43.6961, 1.444209 43.604652))";
+
+        final List<List<LatLng>> empty = new LinkedList<>();
 
         for (int i = 0; i <= 5 ;++i) {
             assertEquals(h3Core.polygonToCellAddresses(latLngPoints, empty, i), handler.polygon_to_cell_addresses(polygonWKT, i));
             assertEquals(handler.polygon_to_cell_addresses(polygonWKT, i), handler.polygon_to_cell_addresses(polygonWKTAlt, i));
-
         }
+
+        final String multiPolygonWKT = "MULTIPOLYGON (((-112.13417747722622 40.48305525857179, -112.07601701040902 40.40458400920371, -112.14044403871432 40.327152363986706, -112.08236892255083 40.24855573342874, -111.95994978862437 40.24734787912595, -111.9020429024643 40.16858374280796, -111.77968666606233 40.16717680240547, -111.71504793475805 40.244544265218366, -111.59256744172903 40.2429483824467, -111.52771940855304 40.32016865585556, -111.5854551484613 40.39901752493811, -111.5205009128757 40.47612241452489, -111.57832080748169 40.55484644293405, -111.70118207844375 40.556423521944474, -111.75917340878016 40.63497990483772, -111.88210082412408 40.63635632640663, -111.9468454993574 40.55918644383781, -112.06964540143417 40.56037241099826), (-111.88876877847025 40.48067243111808, -111.76603234430006 40.47928592430941, -111.70812573681557 40.40060396307876, -111.77287006403081 40.32335096944806, -111.89541610612225 40.32474764935123, -111.95340778646954 40.403387143348745)))";
+        final List<LatLng> multiPolyLatLngPoints = List.of( 
+            new LatLng(40.48305525857179, -112.13417747722622),
+            new LatLng(40.40458400920371, -112.07601701040902),
+            new LatLng(40.327152363986706, -112.14044403871432),
+            new LatLng(40.24855573342874, -112.08236892255083),
+            new LatLng(40.24734787912595, -111.95994978862437),
+            new LatLng(40.16858374280796, -111.9020429024643),
+            new LatLng(40.16717680240547, -111.77968666606233),
+            new LatLng(40.244544265218366, -111.71504793475805),
+            new LatLng(40.2429483824467, -111.59256744172903),
+            new LatLng(40.32016865585556, -111.52771940855304),
+            new LatLng(40.39901752493811, -111.5854551484613),
+            new LatLng(40.47612241452489, -111.5205009128757),
+            new LatLng(40.55484644293405, -111.57832080748169),
+            new LatLng(40.556423521944474, -111.70118207844375),
+            new LatLng(40.63497990483772, -111.75917340878016),
+            new LatLng(40.63635632640663, -111.88210082412408),
+            new LatLng(40.55918644383781, -111.9468454993574),
+            new LatLng(40.56037241099826, -112.06964540143417)
+        );
+
+        final List<List<LatLng>> holeLists = new LinkedList<>();
+        holeLists.add(List.of(
+            new LatLng(40.48067243111808, -111.88876877847025),
+            new LatLng(40.47928592430941, -111.76603234430006),
+            new LatLng(40.40060396307876, -111.70812573681557),
+            new LatLng(40.32335096944806, -111.77287006403081),
+            new LatLng(40.32474764935123, -111.89541610612225),
+            new LatLng(40.403387143348745, -111.95340778646954)
+        ));
+
+        for (int i = 0; i <= 9 ;++i) {
+            assertEquals(h3Core.polygonToCellAddresses(multiPolyLatLngPoints, holeLists, i), handler.polygon_to_cell_addresses(multiPolygonWKT, i));
+        }
+        
     }
 
     public void testcells_to_multipolygon() {

--- a/udf/src/test/java/com/aws/athena/udf/h3/H3AthenaHandlerTest.java
+++ b/udf/src/test/java/com/aws/athena/udf/h3/H3AthenaHandlerTest.java
@@ -2,7 +2,6 @@ package com.aws.athena.udf.h3;
 
 import com.uber.h3core.util.LatLng;
 import com.uber.h3core.H3Core;
-import com.uber.h3core.LengthUnit;
 import org.junit.jupiter.api.Test;
 
 import org.junit.jupiter.api.Assertions;
@@ -40,6 +39,8 @@ public class H3AthenaHandlerTest
         handler = new H3AthenaHandler();
         h3Core = H3Core.newInstance();
     }
+
+    @Test
     public void testlat_lng_to_cell() 
     {
         
@@ -74,6 +75,7 @@ public class H3AthenaHandlerTest
         }
     }
 
+    @Test
     public void testlat_lng_to_cell_address() 
     {
         
@@ -107,6 +109,7 @@ public class H3AthenaHandlerTest
         }
     }
 
+    @Test
     public void testget_icosahedron_faces() {
 
         final double latitude = 43.0;
@@ -126,7 +129,7 @@ public class H3AthenaHandlerTest
 
     }
 
-
+    @Test
     public void testgrid_disk() throws Exception {
         final double latitude = 43.0;
         final double longitude = -42;
@@ -161,6 +164,7 @@ public class H3AthenaHandlerTest
         }
     }
 
+    @Test
     public void testgrid_ring_unsafe() throws Exception {
         final double latitude = 43.0;
         final double longitude = -42;
@@ -195,8 +199,7 @@ public class H3AthenaHandlerTest
         }
     }
 
-
-
+    @Test
     public void test_pentagons() {
         final double latitude = 43.0;
         final double longitude = -42;
@@ -226,6 +229,7 @@ public class H3AthenaHandlerTest
         }
     }
 
+    @Test
     public void testh3_to_geo() {
         assertNull(handler.cell_to_lat_lng((Long)null));
 
@@ -253,6 +257,7 @@ public class H3AthenaHandlerTest
         }
     }
 
+    @Test
     public void testcell_to_lat_lng_wkt() {
         assertNull(handler.cell_to_lat_lng_wkt((Long)null));
 
@@ -264,6 +269,7 @@ public class H3AthenaHandlerTest
     }
 
     /** Tests get_resolution functions. */
+    @Test
     public void testget_resolution() {
         final double latitude = 50.0;
         final double longitude = -43;
@@ -279,6 +285,7 @@ public class H3AthenaHandlerTest
         }
     }
 
+    @Test
     public void test_get_base_cell_number() {
         final double latitude = 40.0;
         final double longitude = -42;
@@ -295,6 +302,7 @@ public class H3AthenaHandlerTest
         
     }
 
+    @Test
     public void teststring_to_h3_two_ways() {
 
         final double latitude = Math.random() * 180.0 - 90.0;
@@ -312,6 +320,7 @@ public class H3AthenaHandlerTest
 
 
     /** Tests cell_to_boundary_wkt functions  */
+    @Test
     public void testcell_to_boundary_wkt() {
         assertNull(handler.cell_to_boundary_wkt((Long)null));
         assertNull(handler.cell_to_boundary_wkt((String)null));
@@ -336,6 +345,7 @@ public class H3AthenaHandlerTest
 
     } 
 
+    @Test
     public void testgrid_path_cells() throws Exception {
         final double latitude = 52.0;
         final double longitude = -4.3;
@@ -364,6 +374,7 @@ public class H3AthenaHandlerTest
 
     }
 
+    @Test
     public void testh3_parent() {
         final double latitude = 52.0;
         final double longitude = -4.3;
@@ -384,7 +395,7 @@ public class H3AthenaHandlerTest
 
     }
 
-
+    @Test
     public void testcell_to_center_child() {
         final double latitude = 52.0;
         final double longitude = -4.3;
@@ -405,6 +416,7 @@ public class H3AthenaHandlerTest
 
     }
 
+    @Test
     public void testcompact_uncompact() {
         final double latitude = 52.0;
         final double longitude = -4.3;
@@ -440,6 +452,7 @@ public class H3AthenaHandlerTest
 
     }
 
+    @Test
     public void testh3_descendants() {
         final double latitude = 52.0;
         final double longitude = -4.3;
@@ -477,6 +490,7 @@ public class H3AthenaHandlerTest
 
 
     /** Tests cell_to_boundary functions as well as cell_to_boundary_sys. */
+    @Test
     public void testcell_to_boundary() {
 
         assertNull(handler.cell_to_boundary((Long)null, ","));
@@ -534,6 +548,7 @@ public class H3AthenaHandlerTest
         }       
     }
 
+    @Test
     public void testis_valid_cell() {
         final double latitude = Math.random() * 180.0 - 90.0;
         final double longitude = Math.random() * 360.0 - 180.0;
@@ -549,6 +564,7 @@ public class H3AthenaHandlerTest
         assertFalse(handler.is_valid_cell((String)null));
     }
 
+    @Test
     public void testis_res_class_iii() {
         final long h3False = 622506764662964223L;
         final long h3True = 617420388352917503L;
@@ -563,15 +579,18 @@ public class H3AthenaHandlerTest
         assertFalse(handler.is_res_class_iii((String)null));
     }
 
+    @Test
     public void testpolygon_to_cells() {
-        final String polygonWKT = "POLYGON((43.604652 1.444209, 47.218371 -1.553621, 50.62925 3.05726, 48.864716 2.349014, 43.6961 7.27178, 43.604652 1.444209))";
+        final String polygonWKT = 
+            "POLYGON ((1.444209 43.604652, -1.553621 47.218371, 3.05726 50.62925, 2.349014 48.864716, 7.27178 43.6961, 1.444209 43.604652))";
         final List<LatLng> latLngPoints = List.of(new LatLng(43.604652,1.444209),
                                                       new LatLng(47.218371, -1.553621),
                                                       new LatLng(50.62925, 3.05726),
                                                       new LatLng(48.864716, 2.349014),
                                                       new LatLng(43.6961, 7.27178),
                                                       new LatLng(43.604652, 1.444209));
-        final String polygonWKTAlt = "POLYGON  ((43.604652 1.444209, 47.218371 -1.553621, 50.62925 3.05726, 48.864716 2.349014, 43.6961 7.27178, 43.604652 1.444209))";
+        final String polygonWKTAlt = 
+            "POLYGON ((1.444209 43.604652, -1.553621 47.218371, 3.05726 50.62925, 2.349014 48.864716, 7.27178 43.6961, 1.444209 43.604652))";
 
         final List<List<LatLng>>  empty = new LinkedList<>();
 
@@ -582,6 +601,7 @@ public class H3AthenaHandlerTest
         }
     }
 
+    // @Test
     public void testpolygon_to_cell_addresses() {
         final String polygonWKT = "POLYGON((43.604652 1.444209, 47.218371 -1.553621, 50.62925 3.05726, 48.864716 2.349014, 43.6961 7.27178, 43.604652 1.444209))";
         final List<LatLng> latLngPoints = List.of(new LatLng(43.604652,1.444209),


### PR DESCRIPTION
There's more than a few changes in here, but highlights are:
- Use the GeoJSON format of lng/lat instead of lat/lng pairs
- Use NGA's Simple Feature libraries for parsing WKT geometries
- Support multipolygons when converting WKT to cell addresses
- Fix a number of bugs
- Refactor functions
- Update configs where it felt prudent